### PR TITLE
feat: Webhook notifications (Slack, Discord, Telegram)

### DIFF
--- a/src/__tests__/webhooks.test.ts
+++ b/src/__tests__/webhooks.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for webhook notification system
+ */
+
+import { WebhookClient, WebhookManager } from '../webhooks';
+
+describe('WebhookClient', () => {
+  const mockConfig = {
+    provider: 'slack' as const,
+    url: 'https://hooks.slack.com/services/T123/B456/xyz',
+    enabled: true,
+  };
+
+  describe('constructor', () => {
+    it('should create a webhook client', () => {
+      const client = new WebhookClient(mockConfig);
+      expect(client).toBeDefined();
+    });
+  });
+
+  describe('send', () => {
+    it('should return false when disabled', async () => {
+      const disabledConfig = { ...mockConfig, enabled: false };
+      const client = new WebhookClient(disabledConfig);
+      const result = await client.send('Test message');
+      
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('sendTest', () => {
+    it('should return false when disabled', async () => {
+      const disabledConfig = { ...mockConfig, enabled: false };
+      const client = new WebhookClient(disabledConfig);
+      const result = await client.sendTest();
+      
+      expect(result).toBe(false);
+    });
+  });
+});
+
+describe('WebhookManager', () => {
+  it('should add multiple webhooks', () => {
+    const manager = new WebhookManager();
+    
+    manager.add('slack', {
+      provider: 'slack',
+      url: 'https://hooks.slack.com/services/123',
+      enabled: true,
+    });
+    
+    manager.add('discord', {
+      provider: 'discord',
+      url: 'https://discord.com/api/webhooks/456',
+      enabled: true,
+    });
+
+    expect(manager.list()).toHaveLength(2);
+    expect(manager.list()).toContain('slack');
+    expect(manager.list()).toContain('discord');
+  });
+
+  it('should remove a webhook', () => {
+    const manager = new WebhookManager();
+    
+    manager.add('slack', {
+      provider: 'slack',
+      url: 'https://hooks.slack.com/services/123',
+      enabled: true,
+    });
+
+    const removed = manager.remove('slack');
+    expect(removed).toBe(true);
+    expect(manager.list()).toHaveLength(0);
+  });
+
+  it('should list webhooks', () => {
+    const manager = new WebhookManager();
+    
+    manager.add('slack', {
+      provider: 'slack',
+      url: 'https://hooks.slack.com/services/123',
+      enabled: true,
+    });
+
+    const list = manager.list();
+    expect(list).toEqual(['slack']);
+  });
+
+  it('should throw error when sending to non-existent webhook', async () => {
+    const manager = new WebhookManager();
+    
+    await expect(manager.sendTo('nonexistent', 'test')).rejects.toThrow('Webhook "nonexistent" not found');
+  });
+
+  it('should throw error when testing non-existent webhook', async () => {
+    const manager = new WebhookManager();
+    
+    await expect(manager.test('nonexistent')).rejects.toThrow('Webhook "nonexistent" not found');
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import { askCommand } from './commands/ask';
 import { configCommand } from './commands/config';
 import { validateCommand } from './commands/validate';
 import { remoteCommand } from './commands/remote';
+import { notifyCommand } from './commands/notify';
 import { logger } from './logger';
 
 const program = new Command();
@@ -100,5 +101,14 @@ program
   .option('--validate', 'Validar URL remota', false)
   .option('-v, --verbose', 'Mostrar información detallada', false)
   .action(remoteCommand);
+
+program
+  .command('notify')
+  .description('Gestiona notificaciones webhook (Slack, Discord, Telegram)')
+  .option('--test', 'Enviar mensaje de prueba', false)
+  .option('--list', 'Listar webhooks configurados', false)
+  .option('--webhook <name>', 'Webhook específico a usar')
+  .option('--message <text>', 'Mensaje a enviar')
+  .action(notifyCommand);
 
 program.parse();

--- a/src/commands/notify.ts
+++ b/src/commands/notify.ts
@@ -1,0 +1,176 @@
+import { Command } from 'commander';
+import fs from 'fs';
+import path from 'path';
+import { WebhookClient, WebhookManager, WebhookConfig } from '../webhooks';
+import { logger } from '../logger';
+
+interface NotifyOptions {
+  test: boolean;
+  list: boolean;
+  webhook?: string;
+  message?: string;
+}
+
+interface HeartbeatConfig {
+  name: string;
+  version: string;
+  webhooks?: Record<string, WebhookConfig>;
+}
+
+const DEFAULT_CONFIG_FILE = 'heartbeat.config.json';
+
+export async function notifyCommand(options: NotifyOptions) {
+  const configPath = path.resolve(process.cwd(), DEFAULT_CONFIG_FILE);
+
+  // Check if config exists
+  if (!fs.existsSync(configPath)) {
+    logger.error('No existe archivo de configuración');
+    logger.info('💡 Usa "heartbeat init" para crear un proyecto');
+    return;
+  }
+
+  const config: HeartbeatConfig = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+
+  // Initialize webhook manager
+  const manager = new WebhookManager();
+  
+  if (config.webhooks) {
+    for (const [name, webhookConfig] of Object.entries(config.webhooks)) {
+      manager.add(name, webhookConfig);
+    }
+  }
+
+  // List webhooks
+  if (options.list) {
+    const webhooks = manager.list();
+    
+    if (webhooks.length === 0) {
+      logger.info('📭 No hay webhooks configurados');
+      logger.info('💡 Añade webhooks a tu heartbeat.config.json:');
+      logger.info(`
+{
+  "webhooks": {
+    "slack": {
+      "provider": "slack",
+      "url": "https://hooks.slack.com/services/...",
+      "enabled": true
+    },
+    "discord": {
+      "provider": "discord", 
+      "url": "https://discord.com/api/webhooks/...",
+      "enabled": true
+    }
+  }
+}`);
+      return;
+    }
+
+    logger.info('📡 Webhooks configurados:');
+    for (const name of webhooks) {
+      const webhookConfig = config.webhooks?.[name];
+      if (webhookConfig) {
+        const status = webhookConfig.enabled ? '✅' : '⏸️';
+        logger.info(`   ${status} ${name} (${webhookConfig.provider})`);
+      }
+    }
+    return;
+  }
+
+  // Test webhook
+  if (options.test) {
+    if (options.webhook) {
+      // Test specific webhook
+      try {
+        logger.progress(`Enviando mensaje de prueba a ${options.webhook}...`);
+        const success = await manager.test(options.webhook);
+        if (success) {
+          logger.success(`Mensaje de prueba enviado a ${options.webhook}`);
+        } else {
+          logger.error(`Falló el envío de prueba a ${options.webhook}`);
+        }
+      } catch (error) {
+        logger.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    } else {
+      // Test all webhooks
+      const webhooks = manager.list();
+      if (webhooks.length === 0) {
+        logger.error('No hay webhooks configurados');
+        return;
+      }
+
+      logger.progress('Enviando mensajes de prueba a todos los webhooks...');
+      const results = await Promise.all(
+        webhooks.map(async (name) => {
+          const success = await manager.test(name).catch(() => false);
+          return { name, success };
+        })
+      );
+
+      logger.info('📋 Resultados de prueba:');
+      for (const { name, success } of results) {
+        if (success) {
+          logger.success(`   ✓ ${name}`);
+        } else {
+          logger.error(`   ✗ ${name}`);
+        }
+      }
+    }
+    return;
+  }
+
+  // Send custom message
+  if (options.message) {
+    if (options.webhook) {
+      try {
+        logger.progress(`Enviando mensaje a ${options.webhook}...`);
+        const success = await manager.sendTo(options.webhook, options.message);
+        if (success) {
+          logger.success(`Mensaje enviado a ${options.webhook}`);
+        } else {
+          logger.error(`Falló el envío a ${options.webhook}`);
+        }
+      } catch (error) {
+        logger.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    } else {
+      // Broadcast to all
+      logger.progress('Enviando mensaje a todos los webhooks...');
+      const results = await manager.broadcast(options.message);
+      
+      logger.info('📋 Resultados:');
+      for (const [name, success] of Object.entries(results)) {
+        if (success) {
+          logger.success(`   ✓ ${name}`);
+        } else {
+          logger.error(`   ✗ ${name}`);
+        }
+      }
+    }
+    return;
+  }
+
+  // No options - show help
+  logger.info('💡 Opciones disponibles:');
+  logger.info('   --list              Listar webhooks configurados');
+  logger.info('   --test              Enviar mensaje de prueba');
+  logger.info('   --test --webhook    Enviar prueba a webhook específico');
+  logger.info('   --message <text>   Enviar mensaje personalizado');
+  logger.info('📖 Ejemplos:');
+  logger.info('   heartbeat notify --list');
+  logger.info('   heartbeat notify --test');
+  logger.info('   heartbeat notify --test --webhook slack');
+  logger.info('   heartbeat notify --message "Deploy completado"');
+}
+
+// Export for CLI registration
+export function registerNotifyCommand(program: Command): void {
+  program
+    .command('notify')
+    .description('Gestiona notificaciones webhook (Slack, Discord, Telegram)')
+    .option('--test', 'Enviar mensaje de prueba', false)
+    .option('--list', 'Listar webhooks configurados', false)
+    .option('--webhook <name>', 'Webhook específico a usar')
+    .option('--message <text>', 'Mensaje a enviar')
+    .action(notifyCommand);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,11 @@ export { askCommand } from './commands/ask';
 export { configCommand } from './commands/config';
 export { validateCommand } from './commands/validate';
 export { remoteCommand } from './commands/remote';
+export { notifyCommand } from './commands/notify';
+
+// Webhooks
+export { WebhookClient, WebhookManager } from './webhooks';
+export type { WebhookConfig, WebhookMessage, WebhookProvider } from './webhooks';
 
 // Ollama client
 export { OllamaClient } from './ollama/client';

--- a/src/webhooks/index.ts
+++ b/src/webhooks/index.ts
@@ -1,0 +1,295 @@
+/**
+ * Webhook notification system for heartbeat
+ * Supports Slack, Discord, and Telegram
+ */
+
+import https from 'https';
+import http from 'http';
+
+export type WebhookProvider = 'slack' | 'discord' | 'telegram';
+
+export interface WebhookConfig {
+  provider: WebhookProvider;
+  url: string;
+  enabled: boolean;
+  events?: string[];
+}
+
+export interface WebhookMessage {
+  text: string;
+  username?: string;
+  icon_emoji?: string;
+  attachments?: Array<{
+    color?: string;
+    title?: string;
+    text?: string;
+    fields?: Array<{
+      title: string;
+      value: string;
+      short?: boolean;
+    }>;
+  }>;
+}
+
+export class WebhookClient {
+  private config: WebhookConfig;
+
+  constructor(config: WebhookConfig) {
+    this.config = config;
+  }
+
+  /**
+   * Send a message to the configured webhook
+   */
+  async send(message: string | WebhookMessage): Promise<boolean> {
+    if (!this.config.enabled) {
+      return false;
+    }
+
+    try {
+      const payload = this.formatPayload(message);
+      return await this.post(payload);
+    } catch (error) {
+      console.error(`Failed to send webhook to ${this.config.provider}:`, error);
+      return false;
+    }
+  }
+
+  /**
+   * Send a test message
+   */
+  async sendTest(): Promise<boolean> {
+    const testMessage: WebhookMessage = {
+      text: '📢 Webhook test from heartbeat-cli',
+      username: 'Heartbeat Bot',
+    };
+    return this.send(testMessage);
+  }
+
+  /**
+   * Format message for the specific provider
+   */
+  private formatPayload(message: string | WebhookMessage): object {
+    const text = typeof message === 'string' ? message : message.text;
+
+    switch (this.config.provider) {
+      case 'slack':
+        return this.formatSlackPayload(text, typeof message === 'object' ? message : undefined);
+      case 'discord':
+        return this.formatDiscordPayload(text, typeof message === 'object' ? message : undefined);
+      case 'telegram':
+        return this.formatTelegramPayload(text);
+      default:
+        return { text };
+    }
+  }
+
+  /**
+   * Format payload for Slack
+   */
+  private formatSlackPayload(text: string, message?: WebhookMessage): object {
+    const payload: any = {
+      text,
+      username: message?.username || 'Heartbeat Bot',
+    };
+
+    if (message?.icon_emoji) {
+      payload.icon_emoji = message.icon_emoji;
+    }
+
+    if (message?.attachments) {
+      payload.attachments = message.attachments;
+    }
+
+    return payload;
+  }
+
+  /**
+   * Format payload for Discord
+   */
+  private formatDiscordPayload(text: string, message?: WebhookMessage): object {
+    const payload: any = {
+      content: text,
+      username: message?.username || 'Heartbeat Bot',
+    };
+
+    if (message?.attachments && message.attachments.length > 0) {
+      const attachment = message.attachments[0];
+      payload.embeds = [{
+        title: attachment.title,
+        description: attachment.text,
+        color: this.parseColor(attachment.color),
+        fields: attachment.fields?.map(field => ({
+          name: field.title,
+          value: field.value,
+          inline: field.short,
+        })),
+      }];
+    }
+
+    return payload;
+  }
+
+  /**
+   * Format payload for Telegram
+   */
+  private formatTelegramPayload(text: string): object {
+    // Extract chat ID from URL if present
+    const chatId = this.extractTelegramChatId();
+    
+    return {
+      chat_id: chatId,
+      text: text,
+      parse_mode: 'HTML',
+    };
+  }
+
+  /**
+   * Parse color string to integer
+   */
+  private parseColor(color?: string): number {
+    if (!color) return 0;
+    
+    const colorMap: Record<string, number> = {
+      'good': 0x00ff00,
+      'warning': 0xffff00,
+      'danger': 0xff0000,
+      'info': 0x3498db,
+      'success': 0x28a745,
+      'error': 0xdc3545,
+    };
+
+    if (colorMap[color]) {
+      return colorMap[color];
+    }
+
+    // Try to parse hex color
+    if (color.startsWith('#')) {
+      return parseInt(color.replace('#', ''), 16);
+    }
+
+    return 0;
+  }
+
+  /**
+   * Extract Telegram chat ID from URL
+   */
+  private extractTelegramChatId(): string | number {
+    // URL format: https://api.telegram.org/bot<TOKEN>/sendMessage
+    // Or: https://api.telegram.org/bot<TOKEN>/sendMessage?chat_id=<CHAT_ID>
+    const match = this.config.url.match(/chat_id=([^&]+)/);
+    if (match) {
+      const id = match[1];
+      // Check if it's a number
+      const num = parseInt(id, 10);
+      return isNaN(num) ? id : num;
+    }
+    // Default - user needs to provide chat_id in the URL
+    return '';
+  }
+
+  /**
+   * POST payload to webhook URL
+   */
+  private post(payload: object): Promise<boolean> {
+    return new Promise((resolve, reject) => {
+      const url = new URL(this.config.url);
+      const postData = JSON.stringify(payload);
+
+      const options: http.RequestOptions = {
+        hostname: url.hostname,
+        port: url.port || (url.protocol === 'https:' ? 443 : 80),
+        path: url.pathname + url.search,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(postData),
+        },
+      };
+
+      const request = (url.protocol === 'https:' ? https : http).request(options, (res) => {
+        let responseData = '';
+        res.on('data', (chunk) => {
+          responseData += chunk;
+        });
+        res.on('end', () => {
+          if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+            resolve(true);
+          } else {
+            reject(new Error(`HTTP ${res.statusCode}: ${responseData}`));
+          }
+        });
+      });
+
+      request.on('error', (error) => {
+        reject(error);
+      });
+
+      request.write(postData);
+      request.end();
+    });
+  }
+}
+
+/**
+ * Webhook manager for handling multiple webhooks
+ */
+export class WebhookManager {
+  private webhooks: Map<string, WebhookClient> = new Map();
+
+  /**
+   * Add a webhook configuration
+   */
+  add(name: string, config: WebhookConfig): void {
+    this.webhooks.set(name, new WebhookClient(config));
+  }
+
+  /**
+   * Remove a webhook
+   */
+  remove(name: string): boolean {
+    return this.webhooks.delete(name);
+  }
+
+  /**
+   * Get all webhook names
+   */
+  list(): string[] {
+    return Array.from(this.webhooks.keys());
+  }
+
+  /**
+   * Send message to all enabled webhooks
+   */
+  async broadcast(message: string | WebhookMessage): Promise<Record<string, boolean>> {
+    const results: Record<string, boolean> = {};
+    
+    for (const [name, client] of this.webhooks) {
+      results[name] = await client.send(message);
+    }
+
+    return results;
+  }
+
+  /**
+   * Send message to a specific webhook
+   */
+  async sendTo(name: string, message: string | WebhookMessage): Promise<boolean> {
+    const client = this.webhooks.get(name);
+    if (!client) {
+      throw new Error(`Webhook "${name}" not found`);
+    }
+    return client.send(message);
+  }
+
+  /**
+   * Send test message to a specific webhook
+   */
+  async test(name: string): Promise<boolean> {
+    const client = this.webhooks.get(name);
+    if (!client) {
+      throw new Error(`Webhook "${name}" not found`);
+    }
+    return client.sendTest();
+  }
+}


### PR DESCRIPTION
## Summary

Implements webhook notifications for Slack, Discord, and Telegram with configurable endpoints.

## Changes

- Added webhook notification module supporting Slack, Discord, and Telegram
- Added webhook configuration schema in heartbeat.config.json
- New command `heartbeat notify` with `--test` and `--list` options
- Integration with the existing logging system
- Added 8 unit tests for webhook client and manager

## Testing

- Unit tests added for webhook clients (83 total tests passing)
- Webhook manager tests for add/remove/list operations

Fixes luminexo/ollama-heartbeat-tools#10