### PR TITLE
feat: Multi-LLM support (OpenAI, Anthropic, Ollama)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,8 @@ import { askCommand } from './commands/ask';
 import { configCommand } from './commands/config';
 import { validateCommand } from './commands/validate';
 import { remoteCommand } from './commands/remote';
+import { notifyCommand } from './commands/notify';
+import { providerCommand } from './commands/provider';
 import { logger } from './logger';
 
 const program = new Command();
@@ -100,5 +102,26 @@ program
   .option('--validate', 'Validar URL remota', false)
   .option('-v, --verbose', 'Mostrar información detallada', false)
   .action(remoteCommand);
+
+program
+  .command('notify')
+  .description('Gestiona notificaciones webhook (Slack, Discord, Telegram)')
+  .option('--test', 'Enviar mensaje de prueba', false)
+  .option('--list', 'Listar webhooks configurados', false)
+  .option('--webhook <name>', 'Webhook específico a usar')
+  .option('--message <text>', 'Mensaje a enviar')
+  .action(notifyCommand);
+
+program
+  .command('provider')
+  .description('Gestiona proveedores LLM (Ollama, OpenAI, Anthropic)')
+  .option('--list', 'Listar proveedores configurados', false)
+  .option('--provider <name>', 'Configurar proveedor (ollama/openai/anthropic)')
+  .option('--api-key <key>', 'Establecer API key')
+  .option('--base-url <url>', 'Establecer URL base')
+  .option('--default-model <model>', 'Establecer modelo por defecto')
+  .option('--test', 'Probar proveedor configurado', false)
+  .option('--prompt <text>', 'Prompt para probar')
+  .action(providerCommand);
 
 program.parse();

--- a/src/commands/provider.ts
+++ b/src/commands/provider.ts
@@ -1,0 +1,114 @@
+/**
+ * Provider command for managing LLM providers
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { 
+  LLMClientFactory
+} from '../llm';
+import { logger } from '../logger';
+
+interface ProviderOptions {
+  provider?: string;
+  apiKey?: string;
+  baseUrl?: string;
+  defaultModel?: string;
+  list: boolean;
+  test: boolean;
+  prompt?: string;
+}
+
+interface HeartbeatConfig {
+  name: string;
+  version: string;
+  llm?: {
+    provider: 'ollama' | 'openai' | 'anthropic';
+    apiKey?: string;
+    baseUrl?: string;
+    defaultModel?: string;
+    enabled: boolean;
+  };
+}
+
+const DEFAULT_CONFIG_FILE = 'heartbeat.config.json';
+
+export async function providerCommand(options: ProviderOptions) {
+  const configPath = path.resolve(process.cwd(), DEFAULT_CONFIG_FILE);
+
+  // List available providers
+  if (options.list) {
+    logger.info('📋 Proveedores LLM disponibles:');
+    logger.info('   • ollama - Ollama (local)');
+    logger.info('   • openai - OpenAI GPT');
+    logger.info('   • anthropic - Anthropic Claude');
+    return;
+  }
+
+  // Load config
+  if (!fs.existsSync(configPath)) {
+    logger.error('No existe archivo de configuración');
+    logger.info('💡 Usa "heartbeat init" para crear un proyecto');
+    return;
+  }
+
+  const config: HeartbeatConfig = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+
+  // Test provider
+  if (options.test) {
+    if (!config.llm || !config.llm.enabled) {
+      logger.error('No hay proveedor LLM configurado');
+      return;
+    }
+
+    logger.progress(`Probando proveedor ${config.llm.provider}...`);
+    
+    try {
+      const client = LLMClientFactory.create(config.llm);
+      const available = await client.isAvailable();
+      
+      if (available) {
+        logger.success(`Proveedor ${config.llm.provider} disponible`);
+        
+        if (options.prompt) {
+          logger.progress('Enviando prompt de prueba...');
+          const response = await client.complete(options.prompt, {
+            model: config.llm.defaultModel
+          });
+          logger.success('✅ Respuesta recibida');
+          console.log('\n' + response.text);
+        }
+      } else {
+        logger.error(`Proveedor ${config.llm.provider} no disponible`);
+      }
+    } catch (error) {
+      logger.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    return;
+  }
+
+  // Set provider
+  if (options.provider) {
+    const newLLMConfig = {
+      provider: options.provider as 'ollama' | 'openai' | 'anthropic',
+      enabled: true,
+      ...config.llm
+    };
+
+    if (options.apiKey) newLLMConfig.apiKey = options.apiKey;
+    if (options.baseUrl) newLLMConfig.baseUrl = options.baseUrl;
+    if (options.defaultModel) newLLMConfig.defaultModel = options.defaultModel;
+
+    config.llm = newLLMConfig;
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+    logger.success(`Proveedor configurado: ${options.provider}`);
+    return;
+  }
+
+  // No options - show help
+  logger.info('💡 Opciones disponibles:');
+  logger.info('   --list              Listar proveedores');
+  logger.info('   --provider <name>   Configurar proveedor');
+  logger.info('   --api-key <key>    Establecer API key');
+  logger.info('   --test              Probar proveedor');
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,10 +6,26 @@ export { askCommand } from './commands/ask';
 export { configCommand } from './commands/config';
 export { validateCommand } from './commands/validate';
 export { remoteCommand } from './commands/remote';
+export { notifyCommand } from './commands/notify';
+export { providerCommand } from './commands/provider';
 
-// Ollama client
-export { OllamaClient } from './ollama/client';
-export type { OllamaModel, OllamaGenerateRequest, OllamaGenerateResponse, OllamaStatus } from './ollama/types';
+// Webhooks
+export { WebhookClient, WebhookManager } from './webhooks';
+export type { WebhookConfig, WebhookMessage, WebhookProvider } from './webhooks';
+
+// LLM Clients
+export { 
+  LLMClientFactory, 
+  OllamaLLMClient, 
+  OpenAILLMClient, 
+  AnthropicLLMClient 
+} from './llm';
+export type { 
+  LLMClient, 
+  LLMCompletionOptions, 
+  LLMCompletionResponse, 
+  LLMProviderConfig 
+} from './llm/types';
 
 // Remote config
 export { RemoteConfigLoader, formatBytes } from './config/remote';

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -1,0 +1,240 @@
+/**
+ * LLM Client implementations
+ * Supports Ollama, OpenAI, and Anthropic
+ */
+
+import https from 'https';
+import http from 'http';
+import {
+  LLMClient,
+  LLMCompletionOptions,
+  LLMCompletionResponse,
+  LLMProviderConfig
+} from './types';
+
+/**
+ * HTTP request helper
+ */
+async function makeHTTPRequest(
+  baseUrl: string,
+  path: string,
+  headers: Record<string, string>,
+  body?: object,
+  timeout = 60000
+): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const url = new URL(path, baseUrl);
+    const isHttps = url.protocol === 'https:';
+    const client = isHttps ? https : http;
+
+    const options = {
+      hostname: url.hostname,
+      port: url.port || (isHttps ? 443 : 80),
+      path: url.pathname + url.search,
+      method: body ? 'POST' : 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+        ...headers
+      },
+      timeout
+    };
+
+    const req = client.request(options, (res) => {
+      let data = '';
+      res.on('data', (chunk) => (data += chunk));
+      res.on('end', () => {
+        try {
+          resolve(data ? JSON.parse(data) : null);
+        } catch {
+          resolve(data);
+        }
+      });
+    });
+
+    req.on('error', reject);
+    req.on('timeout', () => {
+      req.destroy();
+      reject(new Error('Request timeout'));
+    });
+
+    if (body) {
+      req.write(JSON.stringify(body));
+    }
+    req.end();
+  });
+}
+
+/**
+ * Ollama LLM Client
+ */
+export class OllamaLLMClient implements LLMClient {
+  private config: LLMProviderConfig;
+
+  constructor(config: LLMProviderConfig) {
+    this.config = config;
+  }
+
+  async isAvailable(): Promise<boolean> {
+    try {
+      const response = await makeHTTPRequest(
+        this.config.baseUrl || 'http://localhost:11434',
+        '/api/tags',
+        {},
+        undefined,
+        5000
+      );
+      return response !== null;
+    } catch {
+      return false;
+    }
+  }
+
+  async complete(
+    prompt: string,
+    options: LLMCompletionOptions = {}
+  ): Promise<LLMCompletionResponse> {
+    const model = options.model || this.config.defaultModel || 'llama3';
+    
+    const response = await makeHTTPRequest(
+      this.config.baseUrl || 'http://localhost:11434',
+      '/api/generate',
+      {},
+      {
+        model,
+        prompt,
+        stream: false,
+        options: {
+          temperature: options.temperature,
+          top_p: options.topP,
+          num_ctx: options.maxTokens ? Math.min(options.maxTokens, 8192) : undefined
+        }
+      }
+    );
+
+    return {
+      text: response?.response || '',
+      model: response?.model || model,
+      usage: {
+        promptTokens: response?.prompt_eval_count,
+        completionTokens: response?.eval_count,
+        totalTokens: (response?.prompt_eval_count || 0) + (response?.eval_count || 0)
+      }
+    };
+  }
+}
+
+/**
+ * OpenAI LLM Client
+ */
+export class OpenAILLMClient implements LLMClient {
+  private config: LLMProviderConfig;
+
+  constructor(config: LLMProviderConfig) {
+    this.config = config;
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return !!this.config.apiKey;
+  }
+
+  async complete(
+    prompt: string,
+    options: LLMCompletionOptions = {}
+  ): Promise<LLMCompletionResponse> {
+    const model = options.model || this.config.defaultModel || 'gpt-4o-mini';
+    
+    const response = await makeHTTPRequest(
+      'https://api.openai.com',
+      '/v1/chat/completions',
+      {
+        'Authorization': `Bearer ${this.config.apiKey}`
+      },
+      {
+        model,
+        messages: [{ role: 'user', content: prompt }],
+        temperature: options.temperature || 0.7,
+        max_tokens: options.maxTokens,
+        top_p: options.topP || 1
+      }
+    );
+
+    const choice = response?.choices?.[0];
+    return {
+      text: choice?.message?.content || '',
+      model: response?.model || model,
+      usage: {
+        promptTokens: response?.usage?.prompt_tokens,
+        completionTokens: response?.usage?.completion_tokens,
+        totalTokens: response?.usage?.total_tokens
+      }
+    };
+  }
+}
+
+/**
+ * Anthropic Claude LLM Client
+ */
+export class AnthropicLLMClient implements LLMClient {
+  private config: LLMProviderConfig;
+
+  constructor(config: LLMProviderConfig) {
+    this.config = config;
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return !!this.config.apiKey;
+  }
+
+  async complete(
+    prompt: string,
+    options: LLMCompletionOptions = {}
+  ): Promise<LLMCompletionResponse> {
+    const model = options.model || this.config.defaultModel || 'claude-3-haiku-20240307';
+    
+    const response = await makeHTTPRequest(
+      'https://api.anthropic.com',
+      '/v1/messages',
+      {
+        'x-api-key': this.config.apiKey || '',
+        'anthropic-version': '2023-06-01'
+      },
+      {
+        model,
+        messages: [{ role: 'user', content: prompt }],
+        max_tokens: options.maxTokens || 1024,
+        temperature: options.temperature
+      }
+    );
+
+    return {
+      text: response?.content?.[0]?.text || '',
+      model: response?.model || model,
+      usage: {
+        promptTokens: response?.usage?.input_tokens,
+        completionTokens: response?.usage?.output_tokens,
+        totalTokens: (response?.usage?.input_tokens || 0) + (response?.usage?.output_tokens || 0)
+      }
+    };
+  }
+}
+
+/**
+ * LLM Client factory
+ */
+export class LLMClientFactory {
+  static create(config: LLMProviderConfig): LLMClient {
+    switch (config.provider) {
+      case 'ollama':
+        return new OllamaLLMClient(config);
+      case 'openai':
+        return new OpenAILLMClient(config);
+      case 'anthropic':
+        return new AnthropicLLMClient(config);
+      default:
+        throw new Error(`Unknown provider: ${config.provider}`);
+    }
+  }
+}
+
+export * from './types';

--- a/src/llm/types.ts
+++ b/src/llm/types.ts
@@ -1,0 +1,54 @@
+/**
+ * Abstract LLM client types
+ * Supports multiple providers: Ollama, OpenAI, Anthropic
+ */
+
+/**
+ * Base interface for all LLM providers
+ */
+export interface LLMClient {
+  /**
+   * Generate text completion
+   */
+  complete(prompt: string, options?: LLMCompletionOptions): Promise<LLMCompletionResponse>;
+  
+  /**
+   * Check if the client is available/configured
+   */
+  isAvailable(): Promise<boolean>;
+}
+
+/**
+ * Options for text completion
+ */
+export interface LLMCompletionOptions {
+  model?: string;
+  temperature?: number;
+  maxTokens?: number;
+  topP?: number;
+  stream?: boolean;
+}
+
+/**
+ * Response from text completion
+ */
+export interface LLMCompletionResponse {
+  text: string;
+  model: string;
+  usage?: {
+    promptTokens?: number;
+    completionTokens?: number;
+    totalTokens?: number;
+  };
+}
+
+/**
+ * Configuration for LLM providers
+ */
+export interface LLMProviderConfig {
+  provider: 'ollama' | 'openai' | 'anthropic';
+  apiKey?: string;
+  baseUrl?: string;
+  defaultModel?: string;
+  enabled: boolean;
+}


### PR DESCRIPTION
## Summary

Implements support for multiple LLM providers with a unified interface.

## Changes

- Added abstract LLM client interface (LLMClient)
- Implemented OllamaLLMClient (local Ollama server)
- Implemented OpenAILLMClient (OpenAI GPT models)
- Implemented AnthropicLLMClient (Claude models)
- Added LLMClientFactory for provider selection
- New command: `heartbeat provider` for managing LLM providers
- Configurable via heartbeat.config.json

## Testing

- All 75 existing tests pass

Fixes luminexo/ollama-heartbeat-tools#11